### PR TITLE
Feature/add device preview for enhanced responsiveness ✅

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:device_preview/device_preview.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -23,7 +24,13 @@ void main() async {
   await dotenv.load(fileName: ".env");
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   setupLocator();
-  runApp(const MyApp());
+
+  runApp(
+    DevicePreview(
+      enabled: !kReleaseMode,
+      builder: (context) => MyApp(),
+    ),
+  );
 }
 
 class NoThumbScrollBehavior extends ScrollBehavior {
@@ -65,6 +72,9 @@ class MyApp extends StatelessWidget {
     }
 
     return MaterialApp.router(
+      // ignore: deprecated_member_use
+      useInheritedMediaQuery: true,
+      locale: DevicePreview.locale(context),
       routerConfig: router,
       scrollBehavior: NoThumbScrollBehavior().copyWith(scrollbars: false),
       title: 'Monumento',
@@ -72,19 +82,22 @@ class MyApp extends StatelessWidget {
         useMaterial3: false,
       ),
       builder: (context, child) {
-        return ResponsiveBreakpoints.builder(
-          child: ScreenUtilInit(
-              designSize: designSize,
-              minTextAdapt: true,
-              builder: (context, _) {
-                return child!;
-              }),
-          breakpoints: [
-            const Breakpoint(start: 0, end: 450, name: MOBILE),
-            const Breakpoint(start: 451, end: 800, name: TABLET),
-            const Breakpoint(start: 801, end: 1920, name: DESKTOP),
-            const Breakpoint(start: 1921, end: double.infinity, name: '4K'),
-          ],
+        return DevicePreview.appBuilder(
+          context,
+          ResponsiveBreakpoints.builder(
+            child: ScreenUtilInit(
+                designSize: designSize,
+                minTextAdapt: true,
+                builder: (context, _) {
+                  return child!;
+                }),
+            breakpoints: [
+              const Breakpoint(start: 0, end: 450, name: MOBILE),
+              const Breakpoint(start: 451, end: 800, name: TABLET),
+              const Breakpoint(start: 801, end: 1920, name: DESKTOP),
+              const Breakpoint(start: 1921, end: double.infinity, name: '4K'),
+            ],
+          ),
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,7 +82,7 @@ dependencies:
   url_launcher: ^6.3.0
   http:
   flutter_gen: ^5.8.0
-
+  device_preview: ^1.2.0 #Approximate how your Flutter app looks and performs on another device.
 
   # SVG / Vector Graphics
   flutter_svg: ^2.0.10+1


### PR DESCRIPTION
## Description

This PR introduces the integration of the `device_preview` package to enhance the development experience by enabling device-specific previews directly within the app. The following changes were made:
- Added the `device_preview` package and wrapped it around the `MaterialApp` in the main entry point.
- Configured the `DevicePreview` settings under the `MaterialApp` widget to allow seamless responsiveness testing.
- Rebases the current branch with `feature/populate-monuments-data-to-firestore` to include the latest updates and ensure compatibility with ongoing changes.

These updates improve the development workflow by allowing real-time previews and testing of UI changes across different device configurations.

Fixes # (issue)

## Type of change

Please delete options that are not relevant:
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting)

## How Has This Been Tested?

1. **Device Preview Testing:**
   - Verified that the `DevicePreview` integration works seamlessly with the `MaterialApp`.
   - Tested responsiveness and UI rendering across multiple device configurations (mobile, tablet, desktop).

2. **Branch Rebase:**
   - Rebased the branch with `feature/populate-monuments-data-to-firestore` mentioned on #192 to include the latest changes and verified no merge conflicts.

### Screenshots

https://github.com/user-attachments/assets/cb845d3e-aa57-4b4b-b16d-2399c58fe4e9

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels
