### PR TITLE
fixed scaffold with navigation which was causing logout button to vanishing in tablet mode

### DIFF
--- a/lib/presentation/home/desktop/widgets/scaffold_with_navigation.dart
+++ b/lib/presentation/home/desktop/widgets/scaffold_with_navigation.dart
@@ -210,6 +210,13 @@ class _NavigationRailDrawerState extends State<_NavigationRailDrawer> {
             height: 18,
           ),
         ),
+        SideMenuItem(
+          title: 'Log Out',
+          onTap: (a, b) {
+            locator<AuthenticationBloc>().add(LogOutPressed());
+          },
+          icon: const Icon(Icons.exit_to_app),
+        ),
       ],
       style: SideMenuStyle(
         selectedColor: AppColor.appPrimary,


### PR DESCRIPTION
## Description

This PR addresses the issue which appears when the app is being used on tablets or with device width 451 and 800 and on apps with  resizable window size 

* added the logout button when the device width is in the given range 
* linked it logically to the firebase authenticator to logout user when the button is clicked

this fixes the issue when the user is using the app on tablet or at specified resolution and now is able to logout completely without hassle

Fixes #194 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* tested it on browser , macos and iphone , ipad simulator for various device widths and had no issue on those 

###Please include screenshots below if applicable.

https://github.com/user-attachments/assets/55b3e8f3-3cec-4bea-9c66-144ceeac1e49

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #194 
- [x] Tag the PR with the appropriate labels