### PR TITLE
Fixes #217 | Update tab bar indicator color to match app theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,6 +86,9 @@ class MyApp extends StatelessWidget {
       title: 'Monumento',
       theme: ThemeData(
         useMaterial3: false,
+        tabBarTheme: TabBarTheme(
+          indicatorColor: AppColor.appPrimary,
+        )
       ),
       builder: (context, child) {
         return DevicePreview.appBuilder(


### PR DESCRIPTION
# Update tab bar indicator color to match app theme

## Description

Changed default blue indicator color in tab bars to app's primary color for visual consistency across the application.

Fixes #217 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
Tested the following scenarios:
- Tab indicator color matches app's primary color
- Color consistency maintained during tab switches
- Tab functionality works as expected
- Theme changes apply correctly

Please include screenshots below if applicable.
![Screenshot_20241229_025418](https://github.com/user-attachments/assets/296f31f2-9299-4925-8494-f9a0521b7e93)
![Screenshot_20241229_025433](https://github.com/user-attachments/assets/cd119979-1787-463e-879c-2a3692f47e33)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #217 
- [x] Tag the PR with the appropriate labels