### PR TITLE
Fix comment box color and text input

### DIFF
--- a/lib/presentation/authentication/mobile/login_view_mobile.dart
+++ b/lib/presentation/authentication/mobile/login_view_mobile.dart
@@ -71,7 +71,7 @@ class _LoginViewMobileState extends State<LoginViewMobile> {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
                                   content: Text(
-                                    state.message,
+                                    "Invalid email or password, please try again.",
                                     style: AppTextStyles.s14(
                                       color: AppColor.appWhite,
                                       fontType: FontType.MEDIUM,

--- a/lib/presentation/authentication/mobile/login_view_mobile.dart
+++ b/lib/presentation/authentication/mobile/login_view_mobile.dart
@@ -77,7 +77,7 @@ class _LoginViewMobileState extends State<LoginViewMobile> {
                                       fontType: FontType.MEDIUM,
                                     ),
                                   ),
-                                  backgroundColor: AppColor.appSecondary,
+                                  backgroundColor: AppColor.appWarningRed,
                                 ),
                               );
                             }

--- a/lib/presentation/feed/desktop/widgets/feed_post_card.dart
+++ b/lib/presentation/feed/desktop/widgets/feed_post_card.dart
@@ -315,9 +315,11 @@ class _FeedPostCardState extends State<FeedPostCard>
                 SizedBox(
                   width: 430,
                   child: TextFormField(
+                    cursorColor: AppColor.appPrimary,
                     focusNode: commentFocusNode,
                     controller: commentController,
                     decoration: InputDecoration(
+                      focusColor: AppColor.appPrimary,
                       suffixIcon: GestureDetector(
                         onTap: () {
                           locator<CommentsBloc>().add(
@@ -326,6 +328,7 @@ class _FeedPostCardState extends State<FeedPostCard>
                               comment: commentController.text,
                             ),
                           );
+                          commentController.clear();
                         },
                         child: Padding(
                           padding: const EdgeInsets.all(8.0),

--- a/lib/presentation/feed/mobile/widgets/comment_bottom_sheet.dart
+++ b/lib/presentation/feed/mobile/widgets/comment_bottom_sheet.dart
@@ -213,9 +213,17 @@ class _CommentScreenState extends State<CommentScreen> {
                 SizedBox(
                   width: MediaQuery.sizeOf(context).width * 2.2 / 3,
                   child: TextFormField(
+                    cursorColor: AppColor.appPrimary,
                     focusNode: commentFocusNode,
                     controller: commentController,
                     decoration: InputDecoration(
+                      focusedBorder: const OutlineInputBorder(
+                        borderSide:
+                            BorderSide(color: AppColor.appPrimary, width: 2),
+                        borderRadius: BorderRadius.all(
+                          Radius.circular(20),
+                        ),
+                      ),
                       suffixIcon: GestureDetector(
                         onTap: () {
                           locator<CommentsBloc>().add(
@@ -224,6 +232,8 @@ class _CommentScreenState extends State<CommentScreen> {
                               comment: commentController.text,
                             ),
                           );
+                          // clear the text field
+                          commentController.clear();
                         },
                         child: Padding(
                           padding: const EdgeInsets.all(8.0),

--- a/lib/utils/app_colors.dart
+++ b/lib/utils/app_colors.dart
@@ -12,4 +12,5 @@ class AppColor {
   static const Color appGrey = Color(0xFF4B5669);
   static const Color appTextGrey = Color(0xFF838B98);
   static const Color appTextLightGrey = Color(0xFF707988);
+  static const Color appWarningRed = Color(0xFFE74C3C);
 }


### PR DESCRIPTION
## Description

Fixes #223 #222 #221 

1.The color on comment box was set to default which is blue. and it was not matching with the theme of the app. Making it look odd.
2.the text field was not getting cleared after submitting the comment.

## Type of change
Changed the focus color or primary color and added code to clear the input text.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on ios and android app

Please include screenshots below if applicable.
![monumento](https://github.com/user-attachments/assets/35f2d1e4-4027-40ec-88a6-cf3e1b668bca)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #223 #222 #221 (Replace xxxx with the GitHub issue number)
- [x] Ui changes