### PR TITLE
fix the alert dialog issue in deskotop view

### DIFF
--- a/lib/presentation/popular_monuments/desktop/monument_details_view_desktop.dart
+++ b/lib/presentation/popular_monuments/desktop/monument_details_view_desktop.dart
@@ -214,7 +214,7 @@ class _MonumentDetailsViewDesktopState
                             textAlign: TextAlign.center,
                           ),
                           content: SizedBox(
-                            height: 320,
+                            height: 400,
                             width: 500,
                             child: Column(
                               children: [


### PR DESCRIPTION
## Description

previously i was unable to press cancel and check-in in the alert box that poped up after pressing the checkin button in monument view because the alert box was too small and and the button was placed outside it causing overflow issue also now there is no overflow issue and i am also able to checkin with my current position

Fixes #242 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

this has been tested on mobile view, desktop view and using macOS as a target build and it works on all three cases

Please include screenshots below if applicable.

https://github.com/user-attachments/assets/04b54f2d-52be-47f2-a220-119ccfbb2241


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #242 
- [x] Tag the PR with the appropriate labels