### PR TITLE
fix(auth): prevent authenticated route access after logout

### DIFF
--- a/lib/presentation/settings/mobile/settings_view_mobile.dart
+++ b/lib/presentation/settings/mobile/settings_view_mobile.dart
@@ -25,7 +25,7 @@ class _SettingsViewMobileState extends State<SettingsViewMobile> {
         bloc: locator<LoginRegisterBloc>(),
         listener: (context, state) {
           if (state is LogOutSuccess) {
-            context.push('/login');
+            context.go('/login');
           }
         },
         child: Container(


### PR DESCRIPTION
## Description
This PR addresses a security vulnerability in the logout flow where users could access authenticated screens after logout by using the back button. The fix replaces `context.push()` with `context.go()` to properly clear the navigation stack upon logout.

Motivation:
- Prevent unauthorized access to protected routes after logout
- Improve security by ensuring proper session termination
- Follow best practices for handling authentication state

Dependencies:
- No new dependencies required
- Uses existing go_router package

Fixes #246 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual testing performed with the following test cases:
1. Logout flow:
   - Navigate to settings
   - Click logout
   - Verify redirect to login screen
   - Attempt to use back button
   - Verify unable to access previous authenticated screens
 

https://github.com/user-attachments/assets/81b799b2-ff1a-466a-98a1-b9c260576c60



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The commit message follows the project's commit convention
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Maintainer Checklist
- [ ] closes #246 
- [ ] Tag the PR with: security, auth, bugfix