### PR TITLE
Removed the indefinite loading state when there are no posts ✅

### DIFF
--- a/lib/presentation/discover/desktop/discover_view_desktop.dart
+++ b/lib/presentation/discover/desktop/discover_view_desktop.dart
@@ -271,11 +271,7 @@ class _DiscoverViewDesktopState extends State<DiscoverViewDesktop> {
               posts.insertAll(posts.length, state.posts);
             }
             return posts.isEmpty
-                ? const Center(
-                    child: CircularProgressIndicator(
-                      color: AppColor.appPrimary,
-                    ),
-                  )
+                ? NoPostsYet()
                 : SingleChildScrollView(
                     child: Padding(
                       padding: const EdgeInsets.all(18.0),
@@ -317,6 +313,18 @@ class _DiscoverViewDesktopState extends State<DiscoverViewDesktop> {
                     ),
                   );
           },
+        ),
+      ),
+    );
+  }
+
+  Widget NoPostsYet() {
+    return Center(
+      child: Text(
+        "You Have No Posts Yet",
+        style: AppTextStyles.s18(
+          color: AppColor.appSecondary,
+          fontType: FontType.MEDIUM,
         ),
       ),
     );

--- a/lib/presentation/discover/mobile/discover_view_mobile.dart
+++ b/lib/presentation/discover/mobile/discover_view_mobile.dart
@@ -240,9 +240,7 @@ class _DiscoverViewMobileState extends State<DiscoverViewMobile> {
               posts.insertAll(posts.length, state.posts);
             }
             return posts.isEmpty
-                ? const Center(
-                    child: CircularProgressIndicator(),
-                  )
+                ? NoPostsYet()
                 : SingleChildScrollView(
                     child: Column(
                       children: [
@@ -305,6 +303,18 @@ class _DiscoverViewMobileState extends State<DiscoverViewMobile> {
                     ),
                   );
           },
+        ),
+      ),
+    );
+  }
+
+  Widget NoPostsYet() {
+    return Center(
+      child: Text(
+        "You have no posts yet",
+        style: AppTextStyles.s14(
+          color: AppColor.appLightGrey,
+          fontType: FontType.REGULAR,
         ),
       ),
     );


### PR DESCRIPTION
## **Description**  

This PR fixes the **Discover Posts View Stuck on Loading** issue where users were not receiving any feedback when no posts were available. Instead of an indefinite loading state, a **"No Posts Yet"** message is displayed.  

### **Motivation & Context:**  
- Users were left without feedback when the Discover screen had no posts.  
- The fix improves UX by providing clear visibility when no content is available.  
- Affects both **mobile** and **web** versions.  


## **Type of Change**  

- [x] **Bug Fix** (Fixes an issue without breaking existing functionality)  
- [ ] **New Feature** (Adds a new, non-breaking feature)  
- [ ] **Breaking Change** (Existing functionality might not work as expected)  
- [ ] **Refactor** (Code improvements without affecting functionality)  
- [ ] **Documentation Update** (Changes related to documentation)  


## **How Has This Been Tested?**  

Please describe the tests conducted to verify the fix. Include test steps for reproduction.  

### **Test Cases:**  
1. **Scenario:** No posts are available.  
   - **Expected Result:** The "No Posts Yet" message is displayed instead of a loading spinner.  
2. **Scenario:** Posts are available.  
   - **Expected Result:** Posts load correctly without unnecessary loading indicators.  

✅ **Tested on:**  
- [x] Mobile (Android/iOS)  
- [x] Web  

📸 **Screenshots (if applicable):**  
**Before Fix**
https://github.com/user-attachments/assets/2c9e3585-cc41-431d-86e3-e1a47e03af16
**After Fix**
https://github.com/user-attachments/assets/08f71108-df26-45a5-83d9-4000c5c455c4

---

## **Checklist**  

- [x] Code follows project style guidelines  
- [x] Performed self-review of the code  
- [ ] Added comments where necessary  
- [ ] Made corresponding updates to documentation  
- [x] No new warnings or errors generated  
- [ ] Added tests to verify the fix or feature works  
- [ ] Existing unit tests pass successfully  
- [ ] Merged and published any dependent changes  

---

## **Maintainer Checklist**  

- [ ] Closes issue **#xxxx** *(Replace xxxx with the GitHub issue number)*  
- [ ] Tagged PR with appropriate labels  
