### PR TITLE
Resolved issue where successful login did not redirect to the home screen ✅

### DIFF
--- a/lib/presentation/authentication/mobile/login_view_mobile.dart
+++ b/lib/presentation/authentication/mobile/login_view_mobile.dart
@@ -81,6 +81,14 @@ class _LoginViewMobileState extends State<LoginViewMobile> {
                                 ),
                               );
                             }
+
+                            if (state is SigninWithGoogleSuccess ||
+                                state is LoginSuccess) {
+                              while (context.canPop()) {
+                                context.pop();
+                              }
+                              context.push('/');
+                            }
                           },
                           child: BlocBuilder<LoginRegisterBloc,
                               LoginRegisterState>(
@@ -94,12 +102,6 @@ class _LoginViewMobileState extends State<LoginViewMobile> {
                                     ),
                                   ),
                                 );
-                              }
-                              if (state is SigninWithGoogleSuccess) {
-                                while (context.canPop() == true) {
-                                  context.pop();
-                                }
-                                context.push('/');
                               }
                               return Column(
                                 children: [


### PR DESCRIPTION
# **🚀 Fix Login Navigation Issue (Proper Redirection to Home Screen)**  

## **📌 Description**  
This PR addresses an issue where **users were not being redirected to the home screen after a successful login**. The navigation logic has been updated to ensure **proper redirection**, and additional checks have been added to handle the flow correctly.  

---

## **🔄 Changes**  
- **Updated navigation logic** to redirect to the home screen after a successful login.  
- **Moved navigation logic to `BlocListener`** to prevent conflicts with UI rebuilds.  
- **Fixed the issue where the app remained on the login screen despite a successful login.**  
---

## **✅ Type of Change**  

_Select the appropriate type by marking it with `[x]`._

- [x] **Bug fix** (non-breaking change that fixes an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Refactor (code cleanup, style improvements, linting, etc.)  
- [ ] Documentation update  

---

## **🔬 How Has This Been Tested?**  
- [x] Android Emulator  
- [x] iOS Simulator  
- [x] Physical Device  
- [x] Web  

### **Steps to Reproduce & Verify the Fix**  

**Before Fix:** 
1. Users logged in but were not redirected to the home screen.  
2. `context.push('/')` was inside `BlocBuilder`, causing UI rebuild conflicts.  
3. App remained on the login screen despite successful authentication.  
 
### Video before
https://github.com/user-attachments/assets/4c3b4d51-97e0-4a9d-ad29-dd16bd90ee1b

**After Fix:** 
1. Users are properly redirected to `/` after a successful login.  
2. `BlocListener` now **handles navigation separately**, avoiding UI conflicts.  

### Video After
[login_success.webm](https://github.com/user-attachments/assets/a6aec499-1c7b-43de-80bd-9e5d5d6c2d69)

---
## **📌 Checklist**  

- [x] My code follows the project’s coding standards.  
- [x] I have reviewed my own code and verified functionality.  
- [x] I have added comments to explain **hard-to-understand areas**.  
- [x] No **new warnings** were introduced.  
- [x] All **existing & new unit tests pass**.  
- [x] Documentation (if applicable) has been updated.  
- [x] Dependent changes (if any) have been merged & published.  

---

## **🛠️ Maintainer Checklist**  
- [ ] Closes #XXXX _(Replace XXXX with issue number)_  
- [ ] Tagged the PR with the appropriate labels.  

