### PR TITLE
Missing Google logo asset in `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -156,6 +156,7 @@ flutter:
     - assets/ml/
     - assets/aossie.png
     - assets/monumento_logo.svg
+    - assets/google_logo.png
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
Fixes #270

## Description

This PR fixes the issue where the app fails to load the Google logo asset by adding it to the `pubspec.yaml` file's assets section.

## Screenshot
### Before
<img src="https://github.com/user-attachments/assets/11f46309-e35f-4beb-a3f5-2b414d058df3" width=300px>

### After
<img src="https://github.com/user-attachments/assets/03e236fb-754b-4fd2-929c-fdd6937e2fd7" width=300px>

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

- Verified the app loads without asset errors
- Confirmed the Google logo displays properly on the authentication screen

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #270
- [ ] Tag the PR with the appropriate labels