### PR TITLE
273 monument checkout functionality

### DIFF
--- a/lib/application/popular_monuments/monument_checkout/monument_checkout_bloc.dart
+++ b/lib/application/popular_monuments/monument_checkout/monument_checkout_bloc.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:monumento/domain/entities/monument_entity.dart';
+import 'package:monumento/domain/repositories/social_repository.dart';
+
+part 'monument_checkout_event.dart';
+part 'monument_checkout_state.dart';
+
+
+class MonumentCheckoutBloc 
+    extends Bloc<MonumentCheckoutEvent, MonumentCheckoutState> {
+  final SocialRepository _socialRepository;
+  
+  MonumentCheckoutBloc(this._socialRepository)
+      : super(MonumentCheckoutInitial()) {
+    on<RequestMonumentCheckout>(_onRequestCheckout);
+    on<ConfirmMonumentCheckout>(_onConfirmCheckout);
+    on<CheckIfMonumentIsCheckedOut>(_onCheckCheckoutStatus);
+  }
+
+  Future<void> _onRequestCheckout(
+    RequestMonumentCheckout event, 
+    Emitter<MonumentCheckoutState> emit
+  ) async {
+    try {
+      // Check if the monument is currently checked in
+      bool isCheckedIn = await _socialRepository.checkInStatus(
+        monumentId: event.monument.id
+      );
+
+      if (!isCheckedIn) {
+        emit(MonumentCheckoutFailure(
+          message: "You are not checked in to this monument"
+        ));
+        return;
+      }
+
+      // Emit a state indicating checkout is ready to be confirmed
+      emit(MonumentCheckoutRequested(monument: event.monument));
+    } catch (e) {
+      emit(MonumentCheckoutFailure(message: e.toString()));
+    }
+  }
+
+  Future<void> _onConfirmCheckout(
+    ConfirmMonumentCheckout event, 
+    Emitter<MonumentCheckoutState> emit
+  ) async {
+    try {
+      emit(MonumentCheckoutLoading());
+
+      // Perform checkout
+      bool checkoutSuccess = await _socialRepository.monumentCheckOut(
+        monumentId: event.monument.id
+      );
+
+      if (checkoutSuccess) {
+        // This state will only be emitted after a new successful checkout action
+        emit(MonumentCheckedOut());
+      } else {
+        emit(MonumentCheckoutFailure(
+          message: "Failed to check out of the monument"
+        ));
+      }
+    } catch (e) {
+      emit(MonumentCheckoutFailure(message: e.toString()));
+    }
+  }
+
+  Future<void> _onCheckCheckoutStatus(
+    CheckIfMonumentIsCheckedOut event, 
+    Emitter<MonumentCheckoutState> emit
+  ) async {
+    try {
+      emit(MonumentCheckoutLoading());
+
+      // Check checkout status 
+      bool isCheckedIn = await _socialRepository.checkInStatus(
+        monumentId: event.monument.id
+      );
+
+      if (isCheckedIn) {
+        emit(MonumentNotCheckedOut());
+      } else {
+        // Use a different state for monuments already checked out
+        // versus monuments that were just checked out by user action
+        emit(MonumentAlreadyCheckedOut());
+      }
+    } catch (e) {
+      emit(MonumentCheckoutFailure(message: e.toString()));
+    }
+  }
+}

--- a/lib/application/popular_monuments/monument_checkout/monument_checkout_event.dart
+++ b/lib/application/popular_monuments/monument_checkout/monument_checkout_event.dart
@@ -1,0 +1,35 @@
+part of 'monument_checkout_bloc.dart';
+
+sealed class MonumentCheckoutEvent extends Equatable {
+  const MonumentCheckoutEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+final class RequestMonumentCheckout extends MonumentCheckoutEvent {
+  final MonumentEntity monument;
+
+  const RequestMonumentCheckout({required this.monument});
+
+  @override
+  List<Object> get props => [monument];
+}
+
+final class ConfirmMonumentCheckout extends MonumentCheckoutEvent {
+  final MonumentEntity monument;
+
+  const ConfirmMonumentCheckout({required this.monument});
+
+  @override
+  List<Object> get props => [monument];
+}
+
+final class CheckIfMonumentIsCheckedOut extends MonumentCheckoutEvent {
+  final MonumentEntity monument;
+
+  const CheckIfMonumentIsCheckedOut({required this.monument});
+
+  @override
+  List<Object> get props => [monument];
+}

--- a/lib/application/popular_monuments/monument_checkout/monument_checkout_state.dart
+++ b/lib/application/popular_monuments/monument_checkout/monument_checkout_state.dart
@@ -1,0 +1,38 @@
+part of 'monument_checkout_bloc.dart';
+
+sealed class MonumentCheckoutState extends Equatable {
+  const MonumentCheckoutState();
+  
+  @override
+  List<Object> get props => [];
+}
+
+final class MonumentCheckoutInitial extends MonumentCheckoutState {}
+
+final class MonumentCheckoutLoading extends MonumentCheckoutState {}
+
+final class MonumentCheckoutRequested extends MonumentCheckoutState {
+  final MonumentEntity monument;
+
+  const MonumentCheckoutRequested({required this.monument});
+
+  @override
+  List<Object> get props => [monument];
+}
+
+// This state is emitted only on a successful checkout action
+final class MonumentCheckedOut extends MonumentCheckoutState {}
+
+// This state is emitted during the initial load if monument is already checked out
+final class MonumentAlreadyCheckedOut extends MonumentCheckoutState {}
+
+final class MonumentNotCheckedOut extends MonumentCheckoutState {}
+
+final class MonumentCheckoutFailure extends MonumentCheckoutState {
+  final String message;
+  
+  const MonumentCheckoutFailure({required this.message});
+  
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/data/repositories/firebase_social_repository.dart
+++ b/lib/data/repositories/firebase_social_repository.dart
@@ -835,6 +835,32 @@ class FirebaseSocialRepository implements SocialRepository {
     return true;
   }
 
+@override
+Future<bool> monumentCheckOut({required String monumentId}) async {
+  var (userLoggedIn, user) = await authenticationRepository.getUser();
+  if (!userLoggedIn) {
+    throw Exception("User not logged in");
+  }
+
+  QuerySnapshot snap = await _database
+      .collection("users")
+      .doc(user?.uid)
+      .collection("checkIns")
+      .where("monumentId", isEqualTo: monumentId)
+      .get();
+
+  if (snap.docs.isEmpty) {
+    return false;
+  }
+
+  for (var doc in snap.docs) {
+    await doc.reference.delete();
+  }
+
+  return true;
+}
+
+
   @override
   Future<bool> checkInStatus({required String monumentId}) async {
     var (userLoggedIn, user) = await authenticationRepository.getUser();

--- a/lib/domain/repositories/social_repository.dart
+++ b/lib/domain/repositories/social_repository.dart
@@ -76,5 +76,7 @@ abstract interface class SocialRepository {
 
   Future<bool> checkInStatus({required String monumentId});
 
+  Future<bool> monumentCheckOut({required String monumentId});
+
   Future<List<UserModel>> loadUser(List<String> userConnections);
 }

--- a/lib/presentation/popular_monuments/desktop/monument_details_view_desktop.dart
+++ b/lib/presentation/popular_monuments/desktop/monument_details_view_desktop.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:monumento/application/popular_monuments/bookmark_monuments/bookmark_monuments_bloc.dart';
 import 'package:monumento/application/popular_monuments/monument_checkin/monument_checkin_bloc.dart';
+import 'package:monumento/application/popular_monuments/monument_checkout/monument_checkout_bloc.dart';
 import 'package:monumento/application/popular_monuments/monument_details/monument_details_bloc.dart';
 import 'package:monumento/application/popular_monuments/nearby_places/nearby_places_bloc.dart';
 import 'package:monumento/domain/entities/monument_entity.dart';
@@ -47,6 +48,8 @@ class _MonumentDetailsViewDesktopState
         longitude: widget.monument.coordinates[1],
       ),
     );
+    locator<MonumentCheckoutBloc>()
+        .add(CheckIfMonumentIsCheckedOut(monument: widget.monument));
     super.initState();
   }
 
@@ -189,122 +192,219 @@ class _MonumentDetailsViewDesktopState
                 );
               }
             },
-            builder: (context, state) {
-              return Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColor.appPrimary,
-                  ),
-                  onPressed: () {
-                    if (state is MonumentCheckedIn) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text("Already Checked In"),
-                        ),
-                      );
-                      return;
-                    }
-                    showDialog(
-                      context: context,
-                      builder: (context) {
-                        return AlertDialog(
-                          title: const Text(
-                            "Mark this monument as visited?",
-                            textAlign: TextAlign.center,
-                          ),
-                          content: SizedBox(
-                            height: 400,
-                            width: 500,
-                            child: Column(
-                              children: [
-                                Assets.desktop.checkedin.image(),
-                                const SizedBox(
-                                  height: 20,
-                                ),
-                                const Text(
-                                  "Your current location will be used to figure out whether you are near to the Monument or not",
-                                  textAlign: TextAlign.center,
-                                ),
-                                const SizedBox(
-                                  height: 20,
-                                ),
-                                Row(
+            builder: (context, checkinState) {
+              return BlocConsumer<MonumentCheckoutBloc, MonumentCheckoutState>(
+                bloc: locator<MonumentCheckoutBloc>(),
+                listener: (context, checkoutState) {
+                  if (checkoutState is MonumentCheckedOut) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text("Checked Out Successfully"),
+                      ),
+                    );
+                  } else if (checkoutState is MonumentCheckoutFailure) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(checkoutState.message),
+                      ),
+                    );
+                  }
+                },
+                builder: (context, checkoutState) {
+                  // final isCheckedOut = checkoutState is MonumentCheckedOut ||
+                  //    checkoutState is MonumentAlreadyCheckedOut;
+                  return Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColor.appPrimary,
+                      ),
+                      onPressed: () {
+                        if (checkinState is MonumentCheckedIn) {
+                          showDialog(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text(
+                                "Confirm Monument Checkout",
+                                textAlign: TextAlign.center,
+                              ),
+                              content: SizedBox(
+                                height: 200,
+                                width: 500,
+                                child: Column(
                                   children: [
-                                    const Spacer(
-                                      flex: 2,
+                                    const SizedBox(
+                                      height: 20,
                                     ),
-                                    TextButton(
-                                      onPressed: () {
-                                        Navigator.pop(context);
-                                      },
-                                      child: Text(
-                                        "Cancel",
-                                        style: AppTextStyles.s16(
-                                          color: AppColor.appSecondary,
-                                          fontType: FontType.MEDIUM,
-                                          isDesktop: true,
+                                    const Text(
+                                      "You are about to check out from this monument. Your visit duration will be recorded and added to your travel history.",
+                                      textAlign: TextAlign.center,
+                                    ),
+                                    const SizedBox(
+                                      height: 40,
+                                    ),
+                                    Row(
+                                      children: [
+                                        const Spacer(
+                                          flex: 2,
                                         ),
-                                      ),
-                                    ),
-                                    const Spacer(),
-                                    ElevatedButton(
-                                      onPressed: () {
-                                        locator<MonumentCheckinBloc>().add(
-                                          CheckinMonument(
-                                            monument: widget.monument,
+                                        TextButton(
+                                          onPressed: () {
+                                            Navigator.pop(context);
+                                          },
+                                          child: Text(
+                                            "Cancel",
+                                            style: AppTextStyles.s16(
+                                              color: AppColor.appSecondary,
+                                              fontType: FontType.MEDIUM,
+                                              isDesktop: true,
+                                            ),
                                           ),
-                                        );
-                                        Navigator.pop(context);
-                                      },
-                                      style: ElevatedButton.styleFrom(
-                                        backgroundColor: AppColor.appPrimary,
-                                        padding: const EdgeInsets.symmetric(
-                                          horizontal: 24,
-                                          vertical: 12,
                                         ),
-                                      ),
-                                      child: Text(
-                                        "Check In",
-                                        style: AppTextStyles.s14(
-                                          color: AppColor.appSecondary,
-                                          fontType: FontType.MEDIUM,
-                                          isDesktop: true,
+                                        const Spacer(),
+                                        ElevatedButton(
+                                          onPressed: () {
+                                            locator<MonumentCheckoutBloc>().add(
+                                                ConfirmMonumentCheckout(
+                                                    monument: widget.monument));
+                                            Navigator.pop(context);
+                                          },
+                                          style: ElevatedButton.styleFrom(
+                                            backgroundColor:
+                                                AppColor.appPrimary,
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 24,
+                                              vertical: 12,
+                                            ),
+                                          ),
+                                          child: Text(
+                                            "Check Out",
+                                            style: AppTextStyles.s14(
+                                              color: AppColor.appSecondary,
+                                              fontType: FontType.MEDIUM,
+                                              isDesktop: true,
+                                            ),
+                                          ),
                                         ),
-                                      ),
-                                    ),
-                                    const Spacer(
-                                      flex: 2,
+                                        const Spacer(
+                                          flex: 2,
+                                        ),
+                                      ],
                                     ),
                                   ],
                                 ),
-                              ],
+                              ),
+                            ),
+                          );
+                        } else {
+                          showDialog(
+                            context: context,
+                            builder: (context) {
+                              return AlertDialog(
+                                title: const Text(
+                                  "Mark this monument as visited?",
+                                  textAlign: TextAlign.center,
+                                ),
+                                content: SizedBox(
+                                  height: 400,
+                                  width: 500,
+                                  child: Column(
+                                    children: [
+                                      Assets.desktop.checkedin.image(),
+                                      const SizedBox(
+                                        height: 20,
+                                      ),
+                                      const Text(
+                                        "Your current location will be used to figure out whether you are near to the Monument or not",
+                                        textAlign: TextAlign.center,
+                                      ),
+                                      const SizedBox(
+                                        height: 20,
+                                      ),
+                                      Row(
+                                        children: [
+                                          const Spacer(
+                                            flex: 2,
+                                          ),
+                                          TextButton(
+                                            onPressed: () {
+                                              Navigator.pop(context);
+                                            },
+                                            child: Text(
+                                              "Cancel",
+                                              style: AppTextStyles.s16(
+                                                color: AppColor.appSecondary,
+                                                fontType: FontType.MEDIUM,
+                                                isDesktop: true,
+                                              ),
+                                            ),
+                                          ),
+                                          const Spacer(),
+                                          ElevatedButton(
+                                            onPressed: () {
+                                              locator<MonumentCheckinBloc>()
+                                                  .add(
+                                                CheckinMonument(
+                                                  monument: widget.monument,
+                                                ),
+                                              );
+                                              Navigator.pop(context);
+                                            },
+                                            style: ElevatedButton.styleFrom(
+                                              backgroundColor:
+                                                  AppColor.appPrimary,
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                horizontal: 24,
+                                                vertical: 12,
+                                              ),
+                                            ),
+                                            child: Text(
+                                              "Check In",
+                                              style: AppTextStyles.s14(
+                                                color: AppColor.appSecondary,
+                                                fontType: FontType.MEDIUM,
+                                                isDesktop: true,
+                                              ),
+                                            ),
+                                          ),
+                                          const Spacer(
+                                            flex: 2,
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            },
+                          );
+                        }
+                      },
+                      child: Row(
+                        children: [
+                          Assets.icons.icCheckin.svg(
+                            width: 24,
+                            height: 24,
+                          ),
+                          SizedBox(
+                            width: 8.w,
+                          ),
+                          Text(
+                            checkinState is MonumentCheckedIn
+                                ? "Check Out"
+                                : "Check In",
+                            style: AppTextStyles.s16(
+                              color: AppColor.appSecondary,
+                              fontType: FontType.MEDIUM,
+                              isDesktop: true,
                             ),
                           ),
-                        );
-                      },
-                    );
-                  },
-                  child: Row(
-                    children: [
-                      Assets.icons.icCheckin.svg(
-                        width: 24,
-                        height: 24,
+                        ],
                       ),
-                      SizedBox(
-                        width: 8.w,
-                      ),
-                      Text(
-                        state is MonumentCheckedIn ? "Checked In" : "Check In",
-                        style: AppTextStyles.s16(
-                          color: AppColor.appSecondary,
-                          fontType: FontType.MEDIUM,
-                          isDesktop: true,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+                    ),
+                  );
+                },
               );
             },
           ),

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -12,6 +12,7 @@ import 'package:monumento/application/notifications/notifications_bloc.dart';
 import 'package:monumento/application/popular_monuments/bookmark_monuments/bookmark_monuments_bloc.dart';
 import 'package:monumento/application/popular_monuments/monument_checkin/monument_checkin_bloc.dart';
 import 'package:monumento/application/popular_monuments/monument_3d_model/monument_3d_model_bloc.dart';
+import 'package:monumento/application/popular_monuments/monument_checkout/monument_checkout_bloc.dart';
 import 'package:monumento/application/profile/follow/follow_bloc.dart';
 import 'package:monumento/application/popular_monuments/monument_details/monument_details_bloc.dart';
 import 'package:monumento/application/popular_monuments/popular_monuments_bloc.dart';
@@ -76,6 +77,9 @@ void setupLocator() {
       () => NotificationsBloc(locator<SocialRepository>()));
   locator.registerLazySingleton(
       () => MonumentCheckinBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton<MonumentCheckoutBloc>(
+    () => MonumentCheckoutBloc(locator<SocialRepository>())
+  );
   locator.registerLazySingleton(
       () => NearbyPlacesBloc(locator<MonumentRepository>()));
 }


### PR DESCRIPTION
## Description

This PR adds monument checkout functionality to complete the visit lifecycle. Currently, users can check in to monuments but have no way to complete or end their visit, leaving user data in an incomplete state. This implementation adds a "Check Out" button that replaces the "Check In" button when a user is already checked in, with a confirmation dialog that matches the existing design pattern.

Fixes #274 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Checking in to a monument and verifying the button changes to "Check Out"
- Confirming the checkout dialog appears with the correct design and text
- Verifying successful checkout shows the appropriate snackbar message
- Confirming the button reverts to "Check In" after checkout


https://github.com/user-attachments/assets/0006ff18-3b2f-4485-bb47-732401ab5c33



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #274 
- [ ] Tag the PR with the appropriate labels