### PR TITLE
fix: Correct distance validation logic to prevent remote check-ins

### DIFF
--- a/lib/application/popular_monuments/monument_checkin/monument_checkin_bloc.dart
+++ b/lib/application/popular_monuments/monument_checkin/monument_checkin_bloc.dart
@@ -18,52 +18,53 @@ class MonumentCheckinBloc
     on<CheckIfMonumentIsCheckedIn>(_mapCheckIfMonumentIsCheckedInToState);
   }
 
-  Future<void> _mapCheckinMonumentToState(
-      CheckinMonument event, Emitter<MonumentCheckinState> emit) async {
-    try {
-      emit(MonumentCheckinLoading());
-      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
-      if (!serviceEnabled) {
-        emit(const MonumentCheckinFailure(
-            message: "Location services are disabled"));
-        return;
-      }
-      var permission = await Geolocator.checkPermission();
-      if (permission == LocationPermission.denied) {
-        permission = await Geolocator.requestPermission();
-        if (permission == LocationPermission.deniedForever) {
-          emit(const MonumentCheckinFailure(
-              message:
-                  "Location permissions are permanently denied, we cannot request permissions."));
-          return;
-        }
-        if (permission == LocationPermission.denied) {
-          emit(const MonumentCheckinFailure(
-              message: "Location permissions are denied"));
-          return;
-        }
-      }
-      var position = await Geolocator.getCurrentPosition();
-
-      double distance = calculateDistance(position.latitude, position.longitude,
-          event.monument.coordinates[0], event.monument.coordinates[1]);
-      if (distance < 200) {
-        emit(const MonumentCheckinFailure(
-            message: "You are not close enough to check in"));
-        return;
-      }
-
-      if (await _socialRepository.checkInStatus(
-          monumentId: event.monument.id)) {
-        emit(const MonumentCheckinFailure(message: "Already checked in"));
-        return;
-      }
-      await _socialRepository.monumentCheckIn(monumentId: event.monument.id);
-      emit(MonumentCheckinSuccess());
-    } catch (e) {
-      emit(MonumentCheckinFailure(message: e.toString()));
+Future<void> _mapCheckinMonumentToState(
+    CheckinMonument event, Emitter<MonumentCheckinState> emit) async {
+  try {
+    emit(MonumentCheckinLoading());
+    if (await _socialRepository.checkInStatus(monumentId: event.monument.id)) {
+      emit(const MonumentCheckinFailure(message: "Already checked in"));
+      return;
     }
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      emit(const MonumentCheckinFailure(
+          message: "Location services are disabled"));
+      return;
+    }
+    
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.deniedForever) {
+        emit(const MonumentCheckinFailure(
+            message:
+                "Location permissions are permanently denied, we cannot request permissions."));
+        return;
+      }
+      if (permission == LocationPermission.denied) {
+        emit(const MonumentCheckinFailure(
+            message: "Location permissions are denied"));
+        return;
+      }
+    }
+    
+    var position = await Geolocator.getCurrentPosition();
+
+    double distance = calculateDistance(position.latitude, position.longitude,
+        event.monument.coordinates[0], event.monument.coordinates[1]);
+    if (distance > 200) {
+      emit(const MonumentCheckinFailure(
+          message: "You are not close enough to check in"));
+      return;
+    }
+    await _socialRepository.monumentCheckIn(monumentId: event.monument.id);
+    emit(MonumentCheckinSuccess());
+  } catch (e) {
+    emit(MonumentCheckinFailure(message: e.toString()));
   }
+}
+
 
   Future<void> _mapCheckIfMonumentIsCheckedInToState(
       CheckIfMonumentIsCheckedIn event,


### PR DESCRIPTION
## Description

This PR fixes a critical logic error in the monument check-in feature where the distance validation condition was incorrectly implemented. The comparison operator in the distance check was reversed (< instead of >), causing the system to reject users who were actually close to monuments while allowing remote users to check in.
Additionally, this PR includes an optimization where the check for previous check-ins is performed before location validation to avoid unnecessary location service calls.

Fixes #282 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- User more than 200m away from monument - check-in rejected with appropriate message
- User with location services disabled - appropriate error message shown
- User who has already checked in to the monument - "Already checked in" message shown


https://github.com/user-attachments/assets/3589a17e-17c5-4889-a1c3-f82a44eca9e1



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #282 
- [ ] Tag the PR with the appropriate labels