### PR TITLE
feat: Implement dedicated nearby places page with improved UI

### DIFF
--- a/lib/presentation/popular_monuments/mobile/monument_details_view_mobile.dart
+++ b/lib/presentation/popular_monuments/mobile/monument_details_view_mobile.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:chips_choice/chips_choice.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -13,11 +12,11 @@ import 'package:monumento/gen/assets.gen.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/monument_model_view_mobile.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/monument_more_details_view.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/widgets/image_tile_mobile.dart';
+import 'package:monumento/presentation/popular_monuments/mobile/widgets/nearby_places_widget.dart';
 import 'package:monumento/service_locator.dart';
 import 'package:monumento/utils/app_colors.dart';
 import 'package:monumento/utils/app_text_styles.dart';
 import 'package:monumento/utils/constants.dart';
-import 'package:monumento/utils/enums.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class MonumentDetailsViewMobile extends StatefulWidget {
@@ -32,7 +31,6 @@ class MonumentDetailsViewMobile extends StatefulWidget {
 }
 
 class _MonumentDetailsViewMobileState extends State<MonumentDetailsViewMobile> {
-  int _selectedPlace = 0;
 
   @override
   void initState() {
@@ -606,151 +604,74 @@ class _MonumentDetailsViewMobileState extends State<MonumentDetailsViewMobile> {
               BlocConsumer<NearbyPlacesBloc, NearbyPlacesState>(
                 bloc: locator<NearbyPlacesBloc>(),
                 listener: (context, state) {
-                  // TODO: implement listener
+                  // Listener implementation if needed
                 },
                 builder: (context, state) {
                   if (state is NearbyPlacesLoading) {
                     return SizedBox(
-                      width: 1024.w,
-                      child: const Center(
-                        child: CircularProgressIndicator(
-                          color: AppColor.appPrimary,
+                      width: 350.w,
+                      child: const Card(
+                        child: Padding(
+                          padding: EdgeInsets.all(16.0),
+                          child: Center(
+                            child: CircularProgressIndicator(
+                              color: AppColor.appPrimary,
+                            ),
+                          ),
                         ),
                       ),
                     );
                   }
                   if (state is NearbyPlacesLoaded) {
-                    return Card(
-                      child: Container(
-                        width: 350.w,
-                        padding: EdgeInsets.symmetric(
-                          horizontal: 24.w,
-                          vertical: 12.h,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            SizedBox(
-                              height: 12.h,
-                            ),
-                            Text(
-                              "Places Nearby",
-                              style: AppTextStyles.s18(
+                    return NearbyPlacesWidget(
+                      nearbyPlaces: state.nearbyPlaces,
+                      latitude: widget.monument.coordinates[0],
+                      longitude: widget.monument.coordinates[1],
+                    );
+                  }
+                  if (state is NearbyPlacesError) {
+                    return SizedBox(
+                      width: 350.w,
+                      child: Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Column(
+                            children: [
+                              Text(
+                                "Places Nearby",
+                                style: AppTextStyles.s18(
                                   color: AppColor.appSecondary,
-                                  fontType: FontType.MEDIUM),
-                            ),
-                            SizedBox(
-                              height: 12.h,
-                            ),
-                            const Divider(),
-                            ChipsChoice.single(
-                              value: _selectedPlace,
-                              onChanged: (v) {
-                                setState(() {
-                                  _selectedPlace = v;
-                                });
-                              },
-                              choiceItems: const [
-                                C2Choice(
-                                  value: 0,
-                                  label: 'Restaurants',
+                                  fontType: FontType.MEDIUM,
                                 ),
-                                C2Choice(
-                                  value: 1,
-                                  label: 'Toilets',
-                                ),
-                                C2Choice(
-                                  value: 2,
-                                  label: 'Hotels',
-                                ),
-                                C2Choice(
-                                  value: 3,
-                                  label: 'ATMs',
-                                ),
-                                C2Choice(
-                                  value: 4,
-                                  label: 'Supermarkets',
-                                ),
-                                C2Choice(
-                                  value: 5,
-                                  label: 'Pharmacies',
-                                ),
-                              ],
-                            ),
-                            state.nearbyPlaces
-                                    .where((element) =>
-                                        element.featureType ==
-                                        FeatureType.values[_selectedPlace])
-                                    .isEmpty
-                                ? const Padding(
-                                    padding: EdgeInsets.all(8.0),
-                                    child: Center(
-                                      child: Text("No nearby places found"),
+                              ),
+                              const SizedBox(height: 16),
+                              const Text(
+                                "Unable to load nearby places",
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 8),
+                              ElevatedButton(
+                                onPressed: () {
+                                  locator<NearbyPlacesBloc>().add(
+                                    GetNearbyPlaces(
+                                      latitude: widget.monument.coordinates[0],
+                                      longitude: widget.monument.coordinates[1],
                                     ),
-                                  )
-                                : Wrap(
-                                    children: state.nearbyPlaces
-                                        .where((element) =>
-                                            element.featureType ==
-                                            FeatureType.values[_selectedPlace])
-                                        .map(
-                                          (e) => Card(
-                                            child: SizedBox(
-                                              width: 450,
-                                              child: Padding(
-                                                padding:
-                                                    const EdgeInsets.all(8.0),
-                                                child: ListTile(
-                                                  title: Text(e.name),
-                                                  subtitle: Text(e.address),
-                                                  trailing: IconButton(
-                                                    icon: const Icon(
-                                                        Icons.directions),
-                                                    onPressed: () async {
-                                                      if (await canLaunchUrl(
-                                                        Uri.parse(
-                                                            'https://www.google.com/maps/search/?api=1&query=${e.latitude},${e.longitude}'),
-                                                      )) {
-                                                        launchUrl(
-                                                          Uri.parse(
-                                                              'https://www.google.com/maps/search/?api=1&query=${e.latitude},${e.longitude}'),
-                                                        );
-                                                      } else {
-                                                        if (mounted) {
-                                                          showDialog(
-                                                            context: context,
-                                                            builder: (context) {
-                                                              return AlertDialog(
-                                                                title: Text(
-                                                                    "Directions to ${e.name}"),
-                                                                content: Text(
-                                                                    "You can get directions to ${e.name} at ${e.address}"),
-                                                                actions: [
-                                                                  TextButton(
-                                                                    onPressed:
-                                                                        () {
-                                                                      Navigator.pop(
-                                                                          context);
-                                                                    },
-                                                                    child: const Text(
-                                                                        "Close"),
-                                                                  ),
-                                                                ],
-                                                              );
-                                                            },
-                                                          );
-                                                        }
-                                                      }
-                                                    },
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        )
-                                        .toList(),
-                                  )
-                          ],
+                                  );
+                                },
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: AppColor.appPrimary,
+                                ),
+                                child: Text(
+                                  "Retry",
+                                  style: AppTextStyles.s14(
+                                    color: AppColor.appSecondary,
+                                    fontType: FontType.MEDIUM,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     );

--- a/lib/presentation/popular_monuments/mobile/nearby_places_page.dart
+++ b/lib/presentation/popular_monuments/mobile/nearby_places_page.dart
@@ -1,0 +1,384 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:monumento/domain/entities/nearby_place_entity.dart';
+import 'package:monumento/presentation/popular_monuments/mobile/widgets/nearby_places_distance_calculator.dart';
+import 'package:monumento/utils/app_colors.dart';
+import 'package:monumento/utils/app_text_styles.dart';
+import 'package:monumento/utils/enums.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class NearbyPlacesPage extends StatefulWidget {
+  final List<NearbyPlaceEntity> nearbyPlaces;
+  final double latitude;
+  final double longitude;
+
+  const NearbyPlacesPage({
+    Key? key,
+    required this.nearbyPlaces,
+    required this.latitude,
+    required this.longitude,
+  }) : super(key: key);
+
+  @override
+  State<NearbyPlacesPage> createState() => _NearbyPlacesPageState();
+}
+
+class _NearbyPlacesPageState extends State<NearbyPlacesPage> {
+  FeatureType _selectedCategory = FeatureType.restaurant;
+  String _sortOption = 'Name (A-Z)';
+  final List<String> _sortOptions = ['Name (A-Z)', 'Name (Z-A)', 'Distance'];
+  final TextEditingController _searchController = TextEditingController();
+  List<NearbyPlaceEntity> _filteredPlaces = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _updateFilteredPlaces();
+  }
+
+  void _updateFilteredPlaces() {
+    _filteredPlaces = widget.nearbyPlaces
+        .where((place) =>
+            place.featureType == _selectedCategory &&
+            (place.name
+                    .toLowerCase()
+                    .contains(_searchController.text.toLowerCase()) ||
+                place.address
+                    .toLowerCase()
+                    .contains(_searchController.text.toLowerCase())))
+        .toList();
+
+    switch (_sortOption) {
+      case 'Name (A-Z)':
+        _filteredPlaces.sort((a, b) => a.name.compareTo(b.name));
+        break;
+      case 'Name (Z-A)':
+        _filteredPlaces.sort((a, b) => b.name.compareTo(a.name));
+        break;
+      case 'Distance':
+        _filteredPlaces = NearbyPlacesDistanceCalculator.sortPlacesByDistance(
+            _filteredPlaces, widget.latitude, widget.longitude);
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          "Places Nearby",
+          style: AppTextStyles.s18(
+            color: AppColor.appSecondary,
+            fontType: FontType.MEDIUM,
+          ),
+        ),
+        backgroundColor: AppColor.appWhite,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: AppColor.appBlack),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: EdgeInsets.all(16.w),
+            child: TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                hintText: 'Search places...',
+                prefixIcon: const Icon(Icons.search),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: AppColor.appLightGrey),
+                ),
+                filled: true,
+                fillColor: AppColor.appLightGrey.withOpacity(0.2),
+              ),
+              onChanged: (value) {
+                setState(() {
+                  _updateFilteredPlaces();
+                });
+              },
+            ),
+          ),
+          Container(
+            height: 50.h,
+            padding: EdgeInsets.symmetric(horizontal: 16.w),
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: FeatureType.values.map((type) {
+                return Padding(
+                  padding: EdgeInsets.only(right: 8.w),
+                  child: ChoiceChip(
+                    label: Text(
+                      _getCategoryName(type),
+                      style: AppTextStyles.s14(
+                        color: _selectedCategory == type
+                            ? AppColor.appWhite
+                            : AppColor.appSecondary,
+                        fontType: FontType.MEDIUM,
+                      ),
+                    ),
+                    selected: _selectedCategory == type,
+                    selectedColor: AppColor.appPrimary,
+                    backgroundColor: AppColor.appLightGrey,
+                    onSelected: (selected) {
+                      if (selected) {
+                        setState(() {
+                          _selectedCategory = type;
+                          _updateFilteredPlaces();
+                        });
+                      }
+                    },
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Text(
+                  "Sort by:",
+                  style: AppTextStyles.s14(
+                    color: AppColor.appSecondary,
+                    fontType: FontType.REGULAR,
+                  ),
+                ),
+                SizedBox(width: 8.w), 
+                DropdownButton<String>(
+                  value: _sortOption,
+                  icon:
+                      Icon(Icons.arrow_drop_down, color: AppColor.appSecondary),
+                  elevation: 16,
+                  style: AppTextStyles.s14(
+                    color: AppColor.appSecondary,
+                    fontType: FontType.MEDIUM,
+                  ),
+                  underline: SizedBox(), 
+                  onChanged: (String? newValue) {
+                    if (newValue != null) {
+                      setState(() {
+                        _sortOption = newValue;
+                        _updateFilteredPlaces();
+                      });
+                    }
+                  },
+                  items: _sortOptions
+                      .map<DropdownMenuItem<String>>((String value) {
+                    return DropdownMenuItem<String>(
+                      value: value,
+                      child: Text(value),
+                    );
+                  }).toList(),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: _filteredPlaces.isEmpty
+                ? Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.location_off,
+                          size: 64,
+                          color: AppColor.appLightGrey,
+                        ),
+                        SizedBox(height: 16.h),
+                        Text(
+                          "No ${_getCategoryName(_selectedCategory).toLowerCase()} found nearby",
+                          style: AppTextStyles.s16(
+                            color: AppColor.appSecondary,
+                            fontType: FontType.MEDIUM,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : ListView.builder(
+                    padding: EdgeInsets.symmetric(horizontal: 16.w),
+                    itemCount: _filteredPlaces.length,
+                    itemBuilder: (context, index) {
+                      final place = _filteredPlaces[index];
+                      return Card(
+                        elevation: 2,
+                        margin: EdgeInsets.only(bottom: 12.h),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: ListTile(
+                          contentPadding: EdgeInsets.all(16.w),
+                          leading: CircleAvatar(
+                            backgroundColor:
+                                AppColor.appPrimary.withOpacity(0.2),
+                            child: Icon(
+                              _getCategoryIcon(place.featureType),
+                              color: AppColor.appPrimary,
+                            ),
+                          ),
+                          title: Text(
+                            place.name,
+                            style: AppTextStyles.s16(
+                              color: AppColor.appSecondary,
+                              fontType: FontType.MEDIUM,
+                            ),
+                          ),
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              SizedBox(height: 4.h),
+                              Text(
+                                place.address,
+                                style: AppTextStyles.s14(
+                                  color: AppColor.appBlack,
+                                  fontType: FontType.REGULAR,
+                                ),
+                              ),
+                              SizedBox(height: 4.h),
+                              Text(
+                                NearbyPlacesDistanceCalculator
+                                    .getFormattedDistance(
+                                        place.latitude,
+                                        place.longitude,
+                                        widget.latitude,
+                                        widget.longitude),
+                                style: AppTextStyles.s12(
+                                  color: AppColor.appPrimary,
+                                  fontType: FontType.MEDIUM,
+                                ),
+                              ),
+                            ],
+                          ),
+                          trailing: IconButton(
+                            icon: const Icon(
+                              Icons.directions,
+                              color: AppColor.appPrimary,
+                            ),
+                            onPressed: () => _openDirections(place),
+                          ),
+                          onTap: () => _showDetailsDialog(place),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getCategoryName(FeatureType type) {
+    switch (type) {
+      case FeatureType.restaurant:
+        return 'Restaurants';
+      case FeatureType.toilet:
+        return 'Toilets';
+      case FeatureType.hotel:
+        return 'Hotels';
+      case FeatureType.atm:
+        return 'ATMs';
+      case FeatureType.supermarket:
+        return 'Supermarkets';
+      case FeatureType.pharmacy:
+        return 'Pharmacies';
+    }
+  }
+
+  IconData _getCategoryIcon(FeatureType type) {
+    switch (type) {
+      case FeatureType.restaurant:
+        return Icons.restaurant;
+      case FeatureType.toilet:
+        return Icons.wc;
+      case FeatureType.hotel:
+        return Icons.hotel;
+      case FeatureType.atm:
+        return Icons.atm;
+      case FeatureType.supermarket:
+        return Icons.shopping_cart;
+      case FeatureType.pharmacy:
+        return Icons.local_pharmacy;
+    }
+  }
+
+  void _openDirections(NearbyPlaceEntity place) async {
+    final Uri uri = Uri.parse(
+        'https://www.google.com/maps/search/?api=1&query=${place.latitude},${place.longitude}');
+
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    } else {
+      if (mounted) {
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text("Directions to ${place.name}"),
+            content: Text(
+                "Unable to open map directions. The location is at ${place.address}"),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text("Close"),
+              ),
+            ],
+          ),
+        );
+      }
+    }
+  }
+
+  void _showDetailsDialog(NearbyPlaceEntity place) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(place.name),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ListTile(
+              leading: Icon(_getCategoryIcon(place.featureType)),
+              title: Text(_getCategoryName(place.featureType)),
+              contentPadding: EdgeInsets.zero,
+            ),
+            ListTile(
+              leading: const Icon(Icons.location_on),
+              title: Text(place.address),
+              contentPadding: EdgeInsets.zero,
+            ),
+            ListTile(
+              leading: const Icon(Icons.straight),
+              title: Text(NearbyPlacesDistanceCalculator.getFormattedDistance(
+                  place.latitude,
+                  place.longitude,
+                  widget.latitude,
+                  widget.longitude)),
+              contentPadding: EdgeInsets.zero,
+            ),
+            ListTile(
+              leading: const Icon(Icons.location_searching),
+              title: const Text("Tap for directions"),
+              contentPadding: EdgeInsets.zero,
+              onTap: () {
+                Navigator.pop(context);
+                _openDirections(place);
+              },
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text("Close"),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/popular_monuments/mobile/nearby_places_page.dart
+++ b/lib/presentation/popular_monuments/mobile/nearby_places_page.dart
@@ -123,7 +123,7 @@ class _NearbyPlacesPageState extends State<NearbyPlacesPage> {
                     ),
                     selected: _selectedCategory == type,
                     selectedColor: AppColor.appPrimary,
-                    backgroundColor: AppColor.appLightGrey,
+                    backgroundColor: AppColor.unselectedChip,
                     onSelected: (selected) {
                       if (selected) {
                         setState(() {

--- a/lib/presentation/popular_monuments/mobile/widgets/nearby_places_distance_calculator.dart
+++ b/lib/presentation/popular_monuments/mobile/widgets/nearby_places_distance_calculator.dart
@@ -1,0 +1,57 @@
+import 'dart:math';
+import 'package:monumento/domain/entities/nearby_place_entity.dart';
+
+class NearbyPlacesDistanceCalculator {
+  static double calculateDistance(
+      double lat1, double lon1, double lat2, double lon2) {
+    const int earthRadius = 6371;
+
+    final double latDistance = _degreesToRadians(lat2 - lat1);
+    final double lonDistance = _degreesToRadians(lon2 - lon1);
+
+    final double a = sin(latDistance / 2) * sin(latDistance / 2) +
+        cos(_degreesToRadians(lat1)) *
+            cos(_degreesToRadians(lat2)) *
+            sin(lonDistance / 2) *
+            sin(lonDistance / 2);
+
+    final double c = 2 * atan2(sqrt(a), sqrt(1 - a));
+    return earthRadius * c;
+  }
+
+  static double _degreesToRadians(double degrees) {
+    return degrees * (pi / 180);
+  }
+
+  static List<NearbyPlaceEntity> sortPlacesByDistance(
+      List<NearbyPlaceEntity> places,
+      double referenceLatitude,
+      double referenceLongitude) {
+    final List<MapEntry<NearbyPlaceEntity, double>> placesWithDistances =
+        places.map((place) {
+      final double distance = calculateDistance(referenceLatitude,
+          referenceLongitude, place.latitude, place.longitude);
+      return MapEntry(place, distance);
+    }).toList();
+
+    placesWithDistances.sort((a, b) => a.value.compareTo(b.value));
+
+    return placesWithDistances.map((entry) => entry.key).toList();
+  }
+
+  static String getFormattedDistance(
+      double placeLatitude,
+      double placeLongitude,
+      double referenceLatitude,
+      double referenceLongitude) {
+    final double distance = calculateDistance(
+        referenceLatitude, referenceLongitude, placeLatitude, placeLongitude);
+
+    if (distance < 1) {
+      final int meters = (distance * 1000).round();
+      return "$meters m";
+    } else {
+      return "${distance.toStringAsFixed(1)} km";
+    }
+  }
+}

--- a/lib/presentation/popular_monuments/mobile/widgets/nearby_places_widget.dart
+++ b/lib/presentation/popular_monuments/mobile/widgets/nearby_places_widget.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:monumento/domain/entities/nearby_place_entity.dart';
+import 'package:monumento/presentation/popular_monuments/mobile/nearby_places_page.dart';
+import 'package:monumento/utils/app_colors.dart';
+import 'package:monumento/utils/app_text_styles.dart';
+import 'package:monumento/utils/enums.dart';
+
+class NearbyPlacesWidget extends StatelessWidget {
+  final List<NearbyPlaceEntity> nearbyPlaces;
+  final double latitude;
+  final double longitude;
+
+  const NearbyPlacesWidget({
+    Key? key,
+    required this.nearbyPlaces,
+    required this.latitude,
+    required this.longitude,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<FeatureType, int> categoryCount = {};
+    for (final place in nearbyPlaces) {
+      categoryCount[place.featureType] =
+          (categoryCount[place.featureType] ?? 0) + 1;
+    }
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Container(
+        width: 350.w,
+        padding: EdgeInsets.all(16.w),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  "Places Nearby",
+                  style: AppTextStyles.s18(
+                    color: AppColor.appSecondary,
+                    fontType: FontType.MEDIUM,
+                  ),
+                ),
+                Text(
+                  "${nearbyPlaces.length} places",
+                  style: AppTextStyles.s14(
+                    color: AppColor.appBlack,
+                    fontType: FontType.REGULAR,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 16.h),
+            if (categoryCount.isNotEmpty)
+              Wrap(
+                spacing: 8.w,
+                runSpacing: 8.h,
+                children: categoryCount.entries.map((entry) {
+                  return Chip(
+                    label: Text(
+                      "${_getCategoryName(entry.key)}: ${entry.value}",
+                      style: AppTextStyles.s12(
+                        color: AppColor.appSecondary,
+                        fontType: FontType.MEDIUM,
+                      ),
+                    ),
+                    backgroundColor: AppColor.appLightGrey,
+                  );
+                }).toList(),
+              ),
+            if (categoryCount.isNotEmpty) SizedBox(height: 16.h),
+            if (nearbyPlaces.isNotEmpty)
+              ...nearbyPlaces.take(3).map((place) => _buildPlacePreview(place)),
+            if (nearbyPlaces.isEmpty) _buildEmptyState(),
+            if (nearbyPlaces.isNotEmpty) SizedBox(height: 16.h),
+            if (nearbyPlaces.isNotEmpty)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => NearbyPlacesPage(
+                          nearbyPlaces: nearbyPlaces,
+                          latitude: latitude,
+                          longitude: longitude,
+                        ),
+                      ),
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColor.appPrimary,
+                    padding: EdgeInsets.symmetric(vertical: 12.h),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: Text(
+                    "View All Nearby Places",
+                    style: AppTextStyles.s14(
+                      color: AppColor.appSecondary,
+                      fontType: FontType.MEDIUM,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 24.h),
+      width: double.infinity,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.location_off,
+            size: 48,
+            color: AppColor.appLightGrey,
+          ),
+          SizedBox(height: 12.h),
+          Text(
+            "No nearby places found",
+            style: AppTextStyles.s16(
+              color: AppColor.appSecondary,
+              fontType: FontType.MEDIUM,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            "There are no places of interest registered in this area",
+            style: AppTextStyles.s14(
+              color: AppColor.appBlack.withOpacity(0.6),
+              fontType: FontType.REGULAR,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlacePreview(NearbyPlaceEntity place) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 8.h),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: AppColor.appLightGrey,
+            width: 0.5,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            _getCategoryIcon(place.featureType),
+            color: AppColor.appPrimary,
+            size: 20,
+          ),
+          SizedBox(width: 12.w),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  place.name,
+                  style: AppTextStyles.s14(
+                    color: AppColor.appSecondary,
+                    fontType: FontType.MEDIUM,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                SizedBox(height: 2.h),
+                Text(
+                  place.address,
+                  style: AppTextStyles.s12(
+                    color: AppColor.appBlack,
+                    fontType: FontType.REGULAR,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getCategoryName(FeatureType type) {
+    switch (type) {
+      case FeatureType.restaurant:
+        return 'Restaurants';
+      case FeatureType.toilet:
+        return 'Toilets';
+      case FeatureType.hotel:
+        return 'Hotels';
+      case FeatureType.atm:
+        return 'ATMs';
+      case FeatureType.supermarket:
+        return 'Supermarkets';
+      case FeatureType.pharmacy:
+        return 'Pharmacies';
+    }
+  }
+
+  IconData _getCategoryIcon(FeatureType type) {
+    switch (type) {
+      case FeatureType.restaurant:
+        return Icons.restaurant;
+      case FeatureType.toilet:
+        return Icons.wc;
+      case FeatureType.hotel:
+        return Icons.hotel;
+      case FeatureType.atm:
+        return Icons.atm;
+      case FeatureType.supermarket:
+        return Icons.shopping_cart;
+      case FeatureType.pharmacy:
+        return Icons.local_pharmacy;
+    }
+  }
+}

--- a/lib/presentation/popular_monuments/mobile/widgets/nearby_places_widget.dart
+++ b/lib/presentation/popular_monuments/mobile/widgets/nearby_places_widget.dart
@@ -67,7 +67,7 @@ class NearbyPlacesWidget extends StatelessWidget {
                         fontType: FontType.MEDIUM,
                       ),
                     ),
-                    backgroundColor: AppColor.appLightGrey,
+                    backgroundColor: AppColor.unselectedChip,
                   );
                 }).toList(),
               ),

--- a/lib/utils/app_colors.dart
+++ b/lib/utils/app_colors.dart
@@ -13,4 +13,5 @@ class AppColor {
   static const Color appTextGrey = Color(0xFF838B98);
   static const Color appTextLightGrey = Color(0xFF707988);
   static const Color appWarningRed = Color(0xFFE74C3C);
+  static const Color unselectedChip = const Color.fromARGB(255, 222, 226, 234);
 }


### PR DESCRIPTION
## Description

This PR introduces a dedicated NearbyPlacesPage to replace the previously cluttered inline display of nearby places in the monument details view. The new implementation offers a significantly improved user experience with advanced filtering, search functionality, and sorting options.

- A dedicated full-screen interface for browsing nearby places
- Search functionality to filter places by name or address
- Multiple sorting options (A-Z, Z-A, Distance)
- Enhanced visual hierarchy with proper spacing and consistent styling
- Empty state handling for better feedback when no results are found

These changes address user feedback regarding difficulty navigating and finding relevant nearby services when exploring monuments.

Fixes #303 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Testing was performed on both Android and iOS devices with various screen sizes to ensure responsive design and proper functionality:

1. Verified that the "View All Nearby Places" button correctly navigates to the new NearbyPlacesPage
2. Confirmed search functionality works for both place names and addresses
3. Validated all sorting options (A-Z, Z-A, Distance) produce expected results
4. Verified that directions functionality opens Google Maps with correct coordinates
5. Ensured empty states display appropriately when no places are found


https://github.com/user-attachments/assets/91ad1dbe-f261-45c0-9e0e-5512bec5f1b3



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #303 
- [ ] Tag the PR with the appropriate labels