### PR TITLE
Refactor service locator setup into modular methods ✅

### DIFF
--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -31,101 +31,98 @@ import 'data/repositories/appwrite_monument_repository.dart';
 final GetIt locator = GetIt.instance;
 
 void setupLocator() {
+  // Services
+  setupAppServices();
+
+  // Repositories
+  setupAppRepos();
+
+  // Blocs
+  setupAppBlocs();
+}
+
+void setupAppServices() {
+  final client = Client()
+    ..setEndpoint(
+        dotenv.env['APPWRITE_API_ENDPOINT'] ?? 'https://cloud.appwrite.io/v1')
+    ..setProject(dotenv.env['APPWRITE_PROJECT_ID']);
+
+  locator.registerLazySingleton(() => client);
+  locator.registerLazySingleton(() => Databases(locator<Client>()));
+  locator.registerLazySingleton(() => Storage(locator<Client>()));
+  locator.registerLazySingleton(() => Account(locator<Client>()));
+}
+
+void setupAppRepos() {
+  locator.registerLazySingleton<AuthenticationRepository>(
+    () => AppwriteAuthenticationRepository(
+      account: locator<Account>(),
+      database: locator<Databases>(),
+    ),
+  );
+
+  locator.registerLazySingleton<MonumentRepository>(
+    instanceName: 'appwriteMonumentRepository',
+    () => AppwriteMonumentRepository(
+      authenticationRepository: locator<AuthenticationRepository>(),
+      database: locator<Databases>(),
+    ),
+  );
+
   locator
-    // Appwrite related
-    ..registerLazySingleton(() => Client()
-      ..setEndpoint(
-          dotenv.env['APPWRITE_API_ENDPOINT'] ?? 'https://cloud.appwrite.io/v1')
-      ..setProject(dotenv.env['APPWRITE_PROJECT_ID']))
-    ..registerLazySingleton(() => Databases(locator<Client>()))
-    ..registerLazySingleton(() => Storage(locator<Client>()))
-    ..registerLazySingleton<Account>(
-      () => Account(
-        locator<Client>(),
-      ),
-    )
-    ..registerLazySingleton<AuthenticationRepository>(
-      () => AppwriteAuthenticationRepository(
-        account: locator<Account>(),
-        database: locator<Databases>(),
-      ),
-    )
-    ..registerLazySingleton<MonumentRepository>(
-        instanceName: 'appwriteMonumentRepository',
-        () => AppwriteMonumentRepository(
-              authenticationRepository: locator<AuthenticationRepository>(),
-              database: locator<Databases>(),
-            ))
-    ..registerLazySingleton<SocialRepository>(() => AppwriteSocialRepository(
-        authenticationRepository: locator<AuthenticationRepository>(),
-        database: locator<Databases>(),
-        storage: locator<Storage>()))
-    // Firebase related
+      .registerLazySingleton<SocialRepository>(() => AppwriteSocialRepository(
+            authenticationRepository: locator<AuthenticationRepository>(),
+            database: locator<Databases>(),
+            storage: locator<Storage>(),
+          ));
 
-    // Register repositories
-    ..registerLazySingleton<MonumentRepository>(
-      () => AppwriteMonumentRepository(),
-    )
+  locator.registerLazySingleton<MonumentRepository>(
+    () => AppwriteMonumentRepository(),
+  );
+}
 
-    // Register blocs
-    ..registerLazySingleton(() =>
-        AuthenticationBloc(locator<AuthenticationRepository>())
-          ..add(AppStarted()))
-    ..registerLazySingleton(() => LoginRegisterBloc(
-          locator<AuthenticationRepository>(),
-          locator<SocialRepository>(),
-          locator<AuthenticationBloc>(),
-        ))
-    ..registerLazySingleton(
-      () => PopularMonumentsBloc(locator<MonumentRepository>()),
-    )
-    ..registerLazySingleton(
-      () => MonumentDetailsBloc(locator<MonumentRepository>()),
-    )
-    ..registerLazySingleton(
-      () => FeedBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => CommentsBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => RecommendedUsersBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => NewPostBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => FollowBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => ProfilePostsBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => DiscoverPostsBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => SearchBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => DiscoverProfileBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => BookmarkMonumentsBloc(locator<MonumentRepository>()),
-    )
-    ..registerLazySingleton(
-      () => UpdateProfileBloc(
-          locator<SocialRepository>(), locator<AuthenticationRepository>()),
-    )
-    ..registerLazySingleton(
-      () => Monument3dModelBloc(locator<MonumentRepository>()),
-    )
-    ..registerLazySingleton(
-      () => NotificationsBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => MonumentCheckinBloc(locator<SocialRepository>()),
-    )
-    ..registerLazySingleton(
-      () => NearbyPlacesBloc(locator<MonumentRepository>()),
-    );
+void setupAppBlocs() {
+  final authenticationBloc =
+      AuthenticationBloc(locator<AuthenticationRepository>());
+  authenticationBloc.add(AppStarted());
+
+  locator.registerLazySingleton(() => authenticationBloc);
+  locator.registerLazySingleton(() => LoginRegisterBloc(
+        locator<AuthenticationRepository>(),
+        locator<SocialRepository>(),
+        locator<AuthenticationBloc>(),
+      ));
+
+  locator.registerLazySingleton(
+      () => PopularMonumentsBloc(locator<MonumentRepository>()));
+  locator.registerLazySingleton(
+      () => MonumentDetailsBloc(locator<MonumentRepository>()));
+  locator.registerLazySingleton(() => FeedBloc(locator<SocialRepository>()));
+  locator
+      .registerLazySingleton(() => CommentsBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => RecommendedUsersBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(() => NewPostBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(() => FollowBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => ProfilePostsBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => DiscoverPostsBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(() => SearchBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => DiscoverProfileBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => BookmarkMonumentsBloc(locator<MonumentRepository>()));
+  locator.registerLazySingleton(() => UpdateProfileBloc(
+        locator<SocialRepository>(),
+        locator<AuthenticationRepository>(),
+      ));
+  locator.registerLazySingleton(
+      () => Monument3dModelBloc(locator<MonumentRepository>()));
+  locator.registerLazySingleton(
+      () => NotificationsBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => MonumentCheckinBloc(locator<SocialRepository>()));
+  locator.registerLazySingleton(
+      () => NearbyPlacesBloc(locator<MonumentRepository>()));
 }

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -62,7 +62,6 @@ void setupAppRepos() {
   );
 
   locator.registerLazySingleton<MonumentRepository>(
-    instanceName: 'appwriteMonumentRepository',
     () => AppwriteMonumentRepository(
       authenticationRepository: locator<AuthenticationRepository>(),
       database: locator<Databases>(),
@@ -75,10 +74,6 @@ void setupAppRepos() {
             database: locator<Databases>(),
             storage: locator<Storage>(),
           ));
-
-  locator.registerLazySingleton<MonumentRepository>(
-    () => AppwriteMonumentRepository(),
-  );
 }
 
 void setupAppBlocs() {


### PR DESCRIPTION
## Description

This change refactors the `setupLocator` method to replace the cascade operator (`..`) with a more explicit method chaining approach. The aim is to improve the readability and maintainability of the code by breaking down the service and repository setup into smaller, more explicit steps. The main components being registered are:
- **Services**: `Client`, `Databases`, `Storage`, and `Account`.
- **Repositories**: `AuthenticationRepository`, `MonumentRepository`, and `SocialRepository`.
- **Blocs**: Multiple application-level blocs for various functionalities like authentication, feed, discovery, profile, and popular monuments.

Fixes #321 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
manaully

Steps to verify:
1. Run the app and check if the services, repositories, and blocs are accessible via `locator`.
2. Ensure that there are no errors when attempting to retrieve any of the registered components.

Please include screenshots below if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels