### PR TITLE
refactor: integrate image carousel directly into main image area

### DIFF
--- a/lib/presentation/popular_monuments/mobile/monument_details_view_mobile.dart
+++ b/lib/presentation/popular_monuments/mobile/monument_details_view_mobile.dart
@@ -12,6 +12,7 @@ import 'package:monumento/domain/entities/monument_entity.dart';
 import 'package:monumento/gen/assets.gen.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/monument_model_view_mobile.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/monument_more_details_view.dart';
+import 'package:monumento/presentation/popular_monuments/mobile/widgets/image_carousel_mobile.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/widgets/image_tile_mobile.dart';
 import 'package:monumento/service_locator.dart';
 import 'package:monumento/utils/app_colors.dart';
@@ -33,6 +34,8 @@ class MonumentDetailsViewMobile extends StatefulWidget {
 
 class _MonumentDetailsViewMobileState extends State<MonumentDetailsViewMobile> {
   int _selectedPlace = 0;
+  int _currentImageIndex = 0;
+  final PageController _pageController = PageController();
 
   @override
   void initState() {
@@ -51,6 +54,12 @@ class _MonumentDetailsViewMobileState extends State<MonumentDetailsViewMobile> {
       ),
     );
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
   }
 
   String _getTruncatedText(String text, int maxLength) {
@@ -145,19 +154,86 @@ class _MonumentDetailsViewMobileState extends State<MonumentDetailsViewMobile> {
               const SizedBox(
                 height: 15,
               ),
-              ImageTile(index: 0, images: images, width: 367, height: 225),
-              const SizedBox(
-                height: 10,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: List.generate(
-                  images.length,
-                  (index) => ImageTile(index: index, images: images),
+              Container(
+                height: 225.h,
+                width: 367.w,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: PageView.builder(
+                  controller: _pageController,
+                  itemCount: images.length * 1000, 
+                  onPageChanged: (index) {
+                    setState(() {
+                      _currentImageIndex = index % images.length;
+                    });
+                  },
+                  itemBuilder: (context, index) {
+                    final imageIndex = index % images.length;
+                    return GestureDetector(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ImageCarousel(
+                              images: images,
+                              index: imageIndex,
+                            ),
+                          ),
+                        );
+                      },
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(11),
+                          image: DecorationImage(
+                            image: CachedNetworkImageProvider(images[imageIndex]),
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
                 ),
               ),
               const SizedBox(
                 height: 10,
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16.w),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: List.generate(images.length, (index) {
+                    return Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(12.sp),
+                        border: _currentImageIndex == index
+                            ? Border.all(
+                                color: AppColor.appPrimary,
+                                width: 2,
+                              )
+                            : null,
+                      ),
+                      child: ImageTile(
+                        index: index,
+                        images: images,
+                        width: 64.w,
+                        height: 64.h,
+                        onTap: () {
+                          setState(() {
+                            _currentImageIndex = index;
+                          });
+                          final currentPage = _pageController.page?.toInt() ?? 0;
+                          final currentActualIndex = currentPage % images.length;
+                          final pagesToJump = index - currentActualIndex;
+                          _pageController.jumpToPage(currentPage + pagesToJump);
+                        },
+                      ),
+                    );
+                  }),
+                ),
+              ),
+              const SizedBox(
+                height: 20,
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/presentation/popular_monuments/mobile/widgets/image_tile_mobile.dart
+++ b/lib/presentation/popular_monuments/mobile/widgets/image_tile_mobile.dart
@@ -8,17 +8,21 @@ class ImageTile extends StatelessWidget {
   final List<String> images;
   final double? width;
   final double? height;
-  const ImageTile(
-      {super.key,
-      required this.index,
-      required this.images,
-      this.width,
-      this.height});
+  final VoidCallback? onTap;
+  
+  const ImageTile({
+    super.key,
+    required this.index,
+    required this.images,
+    this.width,
+    this.height,
+    this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () {
+      onTap: onTap ?? () {
         Navigator.push(
           context,
           MaterialPageRoute(


### PR DESCRIPTION
## Description

This PR refactors the image carousel functionality by integrating it directly into the main image area instead of displaying a separate carousel on thumbnail clicks. Users can now navigate through monument images directly in the main display area while maintaining thumbnail navigation capabilities. This simplifies the user flow and improves the overall experience when viewing monument photos.

Fixes #336 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

I've tested the refactored carousel on multiple devices with different screen sizes to ensure responsive behavior:
- Tested navigation through images using both the main area swipe and thumbnail clicks
- Verified that the selected thumbnail is properly highlighted when navigating through the main carousel
- Confirmed smooth transitions between images


https://github.com/user-attachments/assets/9434b0b7-96f1-4d0f-b0bf-751b4bd6a554


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #336 
- [ ] Tag the PR with the appropriate labels