### PR TITLE
fix: correct inverted logic in makeExpertCall function

### DIFF
--- a/lib/presentation/popular_monuments/mobile/monument_details_view_mobile.dart
+++ b/lib/presentation/popular_monuments/mobile/monument_details_view_mobile.dart
@@ -771,13 +771,15 @@ Future<void> makeExpertCall(
     LocalExpertEntity expertDetails, BuildContext context) async {
   final Uri phoneUri = Uri(scheme: 'tel', path: expertDetails.phoneNumber);
 
-  if (!await canLaunchUrl(phoneUri)) {
+  if (await canLaunchUrl(phoneUri)) {
     await launchUrl(phoneUri, mode: LaunchMode.externalApplication);
   } else {
-    showAlertDialog(
-      context,
-      "Contact ${expertDetails.name}",
-      "You can contact ${expertDetails.name} at ${expertDetails.phoneNumber}",
-    );
+    if (context.mounted) {
+      showAlertDialog(
+        context,
+        "Contact ${expertDetails.name}",
+        "You can contact ${expertDetails.name} at ${expertDetails.phoneNumber}",
+      );
+    }
   }
 }


### PR DESCRIPTION
## Description

This pull request addresses a bug in the makeExpertCall function within the LocalExpert feature. The bug was caused by inverted conditional logic, which resulted in displaying an alert dialog instead of launching the phone dialer when users attempted to call an expert.

🛠️ Fix Summary:

- Corrected the logic by checking await canLaunchUrl(phoneUri) instead of its negation.

- Added a context.mounted check before attempting to show the alert dialog to prevent runtime issues.

- Ensured consistent use of the existing showAlertDialog utility.

This fix improves the user experience by ensuring the phone dialer opens as expected when tapping the call icon.

Fixes #338 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested the fix
- Verified that tapping the phone icon opens the phone dialer for valid tel: URIs
- Verified that the alert dialog appears only when the dialer cannot be launched
- Confirmed context.mounted check prevents widget lifecycle issues


https://github.com/user-attachments/assets/9824ac6e-8a96-4361-bd16-e5a746d8ef02


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #338 
- [ ] Tag the PR with the appropriate labels