### PR TITLE
Fix auth bug after checkIns collection was fixed

### DIFF
--- a/lib/scripts/setup_appwrite.js
+++ b/lib/scripts/setup_appwrite.js
@@ -365,7 +365,6 @@ async function createUsersCollection(databases, databaseId) {
       Permission.write(Role.users())
     ]
   );
-
   
   // Create CheckIns Subcollection
   const checkInsCollection = await databases.createCollection(
@@ -373,6 +372,7 @@ async function createUsersCollection(databases, databaseId) {
     'checkIns',
     'checkIns',
     [
+      Permission.read(Role.any()),
       Permission.read(Role.users()),
       Permission.create(Role.users()),
       Permission.write(Role.users())


### PR DESCRIPTION
## Description

This pull request includes a minor bug fix to change the `lib/scripts/setup_appwrite.js` file to improve the permissions for the `checkIns` collection.

Permissions update:

* [`lib/scripts/setup_appwrite.js`](diffhunk://#diff-245bc112a42cb2628781836193b17ae2609249f4b7f8f7a0c4ca24cc581fb086L369-R375): Added `Permission.read(Role.any())` to the `checkIns` collection to allow any role to read the collection.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This has been tested on Android Device with the latest code on the `appwrite-migration` branch along with 

Please include screenshots below if applicable.

https://github.com/user-attachments/assets/ccbc7cb7-77fe-4faf-b8db-998e237af2ed


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #352
- [ ] Tag the PR with the appropriate labels