### PR TITLE
Fix like and unlike issue appwrite ✅

### DIFF
--- a/lib/data/repositories/appwrite_social_repository.dart
+++ b/lib/data/repositories/appwrite_social_repository.dart
@@ -1147,65 +1147,64 @@ class AppwriteSocialRepository implements SocialRepository {
     }
 
     try {
-      // Create the unique document ID for this like
-      final postIdPart = postId.substring(0, 18);
-      final userIdPart = user!.uid.substring(0, 17);
-      final likeDocId = "${postIdPart}_${userIdPart}";
-      bool shouldIncrementCount = false;
+      // Check if like already exists
+      final existingLikes = await _database.listDocuments(
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
+        queries: [
+          Query.equal('userId', user!.uid),
+          Query.equal('postId', postId),
+        ],
+      );
 
-      try {
-        // Check if document already exists
-        final existingLikeDoc = await _database.getDocument(
+      if (existingLikes.documents.isNotEmpty) {
+        // Update existing like
+        final existingLike = existingLikes.documents.first;
+        if (existingLike.data['liked'] == true) {
+          return postId; // Already liked
+        }
+
+        await _database.updateDocument(
           databaseId: _databaseId,
           collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
-          documentId: likeDocId,
+          documentId: existingLike.$id,
+          data: {
+            'liked': true,
+            'timestamp': DateTime.now().toIso8601String(),
+          },
         );
-
-        // Document exists - check if we need to update it
-        if (existingLikeDoc.data['likedPost'] != true) {
-          await _database.updateDocument(
-              databaseId: _databaseId,
-              collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
-              documentId: likeDocId,
-              data: {
-                'likedPost': true,
-                'timeStamp': DateTime.now().millisecondsSinceEpoch,
-              });
-          shouldIncrementCount = true;
-        }
-      } catch (e) {
-        // Document doesn't exist - create a new like document
+      } else {
+        // Create new like
         await _database.createDocument(
-            databaseId: _databaseId,
-            collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
-            documentId: likeDocId,
-            data: {
-              'author': user.uid,
-              'timeStamp': DateTime.now().millisecondsSinceEpoch,
-              'postInvolvedId': postId,
-              'likedPost': true,
-            });
-        shouldIncrementCount = true;
+          databaseId: _databaseId,
+          collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
+          documentId: ID.unique(),
+          data: {
+            'userId': user.uid,
+            'postId': postId,
+            'liked': true,
+            'timestamp': DateTime.now().toIso8601String(),
+          },
+        );
       }
 
-      // Only increment count if we actually added a new like
-      if (shouldIncrementCount) {
-        final postDoc = await _database.getDocument(
-            databaseId: _databaseId,
-            collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
-            documentId: postId);
+      // Increment likes count
+      final postDoc = await _database.getDocument(
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
+        documentId: postId,
+      );
 
-        int currentLikes = postDoc.data['likesCount'] ?? 0;
-        await _database.updateDocument(
-            databaseId: _databaseId,
-            collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
-            documentId: postId,
-            data: {
-              'likesCount': currentLikes + 1,
-            });
-      }
+      int currentLikes = postDoc.data['likesCount'] ?? 0;
+      await _database.updateDocument(
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
+        documentId: postId,
+        data: {
+          'likesCount': currentLikes + 1,
+        },
+      );
 
-      // Return the post ID that was updated
       return postId;
     } catch (e) {
       print(e);
@@ -1222,35 +1221,47 @@ class AppwriteSocialRepository implements SocialRepository {
     }
 
     try {
-      // Update like document to false
-      final postIdPart = postId.substring(0, 18);
-      final userIdPart = user!.uid.substring(0, 17);
-      final likeDocId = "${postIdPart}_${userIdPart}";
+      // Find the like document
+      final existingLikes = await _database.listDocuments(
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
+        queries: [
+          Query.equal('userId', user!.uid),
+          Query.equal('postId', postId),
+        ],
+      );
+
+      if (existingLikes.documents.isEmpty) {
+        return postId; // No like to unlike
+      }
+
+      final existingLike = existingLikes.documents.first;
       await _database.updateDocument(
-          databaseId: _databaseId,
-          collectionId: dotenv.env['APPWRITE_LIKES_ID'] ??
-              "postLikes", // Original collection name
-          documentId: likeDocId,
-          data: {
-            'likedPost': false,
-          });
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_LIKES_ID'] ?? "postLikes",
+        documentId: existingLike.$id,
+        data: {
+          'liked': false,
+        },
+      );
 
       // Decrement likes count
       final postDoc = await _database.getDocument(
-          databaseId: _databaseId,
-          collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
-          documentId: postId);
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
+        documentId: postId,
+      );
 
       int currentLikes = postDoc.data['likesCount'] ?? 0;
       await _database.updateDocument(
-          databaseId: _databaseId,
-          collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
-          documentId: postId,
-          data: {
-            'likesCount': (currentLikes - 1) > 0 ? (currentLikes - 1) : 0,
-          });
+        databaseId: _databaseId,
+        collectionId: dotenv.env['APPWRITE_POSTS_ID'] ?? "posts",
+        documentId: postId,
+        data: {
+          'likesCount': (currentLikes - 1) > 0 ? (currentLikes - 1) : 0,
+        },
+      );
 
-      // Return the post ID that was updated
       return postId;
     } catch (e) {
       log("Error unliking post: $e", stackTrace: StackTrace.current);

--- a/lib/scripts/setup_appwrite.js
+++ b/lib/scripts/setup_appwrite.js
@@ -532,9 +532,9 @@ async function setupUsersAttributes(databases, databaseId, collectionId) {
   await new Promise(resolve => setTimeout(resolve, 3000));
 
 }
-
 async function createPostsCollection(databases, databaseId) {
-  return await databases.createCollection(
+  // Create main posts collection
+  const postsCollection = await databases.createCollection(
     databaseId,
     'posts',
     'posts',
@@ -544,11 +544,27 @@ async function createPostsCollection(databases, databaseId) {
       Permission.read(Role.users()),
       Permission.write(Role.users()),
     ]
-  )
+  );
+
+  // Create postLikes subcollection
+  const postLikesCollection = await databases.createCollection(
+    databaseId,
+    'postLikes',
+    'postLikes',
+    [
+      Permission.read(Role.any()),
+      Permission.read(Role.users()),
+      Permission.create(Role.users()),
+      Permission.update(Role.users()),
+      Permission.delete(Role.users()),
+    ]
+  );
+
+  return postsCollection;
 }
 
 async function setupPostsAttributes(databases, databaseId, collectionId) {
-  // Title of the post
+  // Existing post attributes
   await databases.createStringAttribute(
     databaseId,
     collectionId,
@@ -649,9 +665,79 @@ async function setupPostsAttributes(databases, databaseId, collectionId) {
     RelationMutate.SetNull
   );
 
+  // Setup postLikes collection attributes
+  await setupPostLikesAttributes(databases, databaseId, 'postLikes');
+  
   await new Promise(resolve => setTimeout(resolve, 3000));
 }
 
+async function setupPostLikesAttributes(databases, databaseId, collectionId) {
+  // User who liked the post
+  await databases.createStringAttribute(
+    databaseId,
+    collectionId,
+    'userId',
+    255,
+    true,
+    null,
+    false
+  );
+
+  // Post that was liked
+  await databases.createStringAttribute(
+    databaseId,
+    collectionId,
+    'postId',
+    255,
+    true,
+    null,
+    false
+  );
+
+  // Like status
+  await databases.createBooleanAttribute(
+    databaseId,
+    collectionId,
+    'liked',
+    true,
+    null,
+    false
+  );
+
+  // Timestamp of like action
+  await databases.createDatetimeAttribute(
+    databaseId,
+    collectionId,
+    'timestamp',
+    true,
+    null,
+    false
+  );
+
+  // Create relationship between likes and posts
+  await databases.createRelationshipAttribute(
+    databaseId,
+    collectionId,
+    'posts',
+    RelationshipType.ManyToOne,
+    true,
+    'post',
+    null,
+    RelationMutate.Cascade
+  );
+
+  // Create relationship between likes and users
+  await databases.createRelationshipAttribute(
+    databaseId,
+    collectionId,
+    'users',
+    RelationshipType.ManyToOne,
+    true,
+    'user',
+    null,
+    RelationMutate.Cascade
+  );
+}
 async function addSampleMonumentData(databases, databaseId) {
   try {
     console.log('Adding sample monument data...');


### PR DESCRIPTION
## Description

This PR introduces the `postLikes` subcollection in the Appwrite database schema setup and updates the `likePost` method logic to handle duplicate likes more robustly. It ensures that a user can like a post only once and properly updates the like status and the `likesCount` in the post document.

Fixes ( #341)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
manually 


## Screenshot 
**(Before)**
![Screenshot_1744327995](https://github.com/user-attachments/assets/e0c3d752-07b3-49a3-849f-eafb4d996c59)

**(After)**
[fix-login-exception.webm](https://github.com/user-attachments/assets/29d16893-15fe-4a0c-b3b8-6cfe7655f48d)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels
