### PR TITLE
Trigger _showAddOptions to show whether add new post or create ai itinerary ✅

### DIFF
--- a/lib/presentation/home/mobile/home_view_mobile.dart
+++ b/lib/presentation/home/mobile/home_view_mobile.dart
@@ -6,6 +6,7 @@ import 'package:monumento/presentation/community/mobile/community_view_mobile.da
 import 'package:monumento/presentation/discover/mobile/discover_view_mobile.dart';
 import 'package:monumento/presentation/feed/mobile/widgets/new_post_bottom_sheet.dart';
 import 'package:monumento/presentation/feed/mobile/your_feed_view_mobile.dart';
+import 'package:monumento/presentation/itinerary_generation/mobile/itenerary_prefrences_screen.dart';
 import 'package:monumento/presentation/popular_monuments/mobile/popular_monuments_view_mobile.dart';
 import 'package:monumento/presentation/profile_screen/mobile/profile_screen_mobile.dart';
 import 'package:monumento/service_locator.dart';
@@ -36,21 +37,23 @@ class _HomeViewMobileState extends State<HomeViewMobile> {
           const PopularMonumentsViewMobile(),
           const YourFeedViewMobile(),
           Container(),
-          const CommunitiesViewMobile(), // ADD THIS LINE
-
+          const CommunitiesViewMobile(),
           const DiscoverViewMobile(),
-
           const ProfileScreenMobile(),
         ],
       ),
       bottomNavigationBar: BottomNavigationBar(
         onTap: (index) {
           if (index == 2) {
-            NewPostBottomSheet().newPostBottomSheet(context);
+            _showAddOptions(
+              context,
+            ); // show options instead of direct NewPostBottomSheet
           } else {
-            setState(() {
-              selectedIndex = index;
-            });
+            setState(
+              () {
+                selectedIndex = index;
+              },
+            );
           }
         },
         backgroundColor: AppColor.appWhite,
@@ -150,6 +153,44 @@ class _HomeViewMobileState extends State<HomeViewMobile> {
         ],
         currentIndex: selectedIndex,
       ),
+    );
+  }
+
+  void _showAddOptions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (BuildContext context) {
+        return SafeArea(
+          child: Wrap(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.post_add, color: Colors.blue),
+                title: const Text("Add Post"),
+                onTap: () {
+                  Navigator.pop(context);
+                  NewPostBottomSheet().newPostBottomSheet(context);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.route, color: Colors.green),
+                title: const Text("AI Itinerary"),
+                onTap: () {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ItineraryPreferencesScreen(),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Description

Added a new `_showAddOptions` method in `HomeViewMobile` to handle the **Add Post** button behavior.
When the user taps the ➕ button in the `BottomNavigationBar`, instead of directly opening the `NewPostBottomSheet`, a **bottom sheet menu** now appears with two options:

* **Add Post** → opens the existing `NewPostBottomSheet`.
* **AI Itinerary** → navigates to the `ItineraryPreferencesScreen`.

This improves usability by allowing users to choose between creating a post or generating an AI itinerary.

## Screen shot

<img width="1080" height="2400" alt="Screenshot_1755589521" src="https://github.com/user-attachments/assets/d7c62d14-c913-4042-901d-458cb7972277" />

---

## Type of change

* [x] New feature (non-breaking change which adds functionality)

---

## How Has This Been Tested?

* Manually tested on device/emulator.
* Verified that tapping the **Add Post** button now opens the bottom sheet with two options.
* Confirmed that selecting **Add Post** opens the `NewPostBottomSheet`.
* Confirmed that selecting **AI Itinerary** navigates to the `ItineraryPreferencesScreen`.

---

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works (manual test for now)
* [ ] New and existing unit tests pass locally with my changes

---

## Maintainer Checklist

* [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
* [ ] Tag the PR with the appropriate labels



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an “AI Itinerary” option accessible from the Add menu, guiding users to set preferences and generate itineraries.

- Improvements
  - Updated Add menu to a modern bottom sheet with clear choices: “Add Post” and “AI Itinerary.”
  - Reordered home tabs, placing Communities before Discover for quicker access.

- Changes
  - Removed the Profile tab from the main navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->